### PR TITLE
Tweak HipChat colours to be a bit more useful

### DIFF
--- a/lib/mauve/notifiers/hipchat.rb
+++ b/lib/mauve/notifiers/hipchat.rb
@@ -27,13 +27,13 @@ module Mauve
       def send_alert(destination, alert, all_alerts, conditions = {})
         msg = prepare_message(destination, alert, all_alerts, conditions)
 
-        colour = case alert.level
-          when :urgent
-            "red"
-          when :normal
-            "yellow"
+        colour = case alert.update_type
+          when 'cleared'
+            'green'
+          when 'acknowledged'
+            'yellow'
           else
-            "green"
+            'red'
         end
         
         opts = {


### PR DESCRIPTION
> It would be lovely if cleared messages were green
> —- Tom Hill

I switched from  using `alert.level` (which pretty much always seems to be urgent) to perhaps the more useful update_type so we can case on cleared/acked/raised.