### PR TITLE
rip out the require 'locale'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,9 @@ gem "rack-protection", "~> 1.5.2"
 gem "rack-flash3", "~> 1.0.5"
 gem "tilt",        "~> 1.4.1"
 gem "sinatra",     "~> 1.4.5"
-gem "locale",      "~> 2.1.0"
 
 group :test do
+  gem "locale",      "~> 2.1.0"
   gem "simplecov", :require => false
   gem "rack-test", "~> 0.6.3"
   gem "webmock",   "~> 1.19.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     bcrypt (3.1.11)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    daemons (1.2.4)
+    daemons (1.2.6)
     data_objects (0.10.17)
       addressable (~> 2.1)
     datamapper (1.2.0)
@@ -75,11 +75,11 @@ GEM
     json_pure (1.8.6)
     locale (2.1.2)
     log4r (1.1.10)
-    mini_portile2 (2.2.0)
-    multi_json (1.12.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    public_suffix (2.0.5)
+    mini_portile2 (2.3.0)
+    multi_json (1.13.1)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    public_suffix (3.0.1)
     rack (1.5.5)
     rack-flash3 (1.0.5)
       rack
@@ -92,11 +92,11 @@ GEM
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    simplecov (0.14.1)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.1)
+    simplecov-html (0.10.2)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -148,4 +148,4 @@ DEPENDENCIES
   webmock (~> 1.19.0)
 
 BUNDLED WITH
-   1.13.6
+   1.16.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ mauvealert (3.16.0) UNRELEASED; urgency=medium
   * Make authentication work for AJAX requests (#22, !3)
   * Change 'Events' nav item to load day list instead of calendar (#18, !3)
 
+  [ Telyn Roat]
+  * Removed need for locale gem outside of tests. (github pr #3)
+
  -- Patrick J Cherry <patrick@bytemark.co.uk>  Mon, 01 Aug 2017 14:37:32 +0100
 
 mauvealert (3.15.15-1) stable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,6 @@ Architecture: any
 Pre-Depends: libjs-jquery
 Depends: adduser, lsb-base, ruby | ruby-interpreter, ruby-bundler, ${shlibs:Depends}, ${misc:Depends}
 Suggests: mauvealert-client
-Recommends: ruby-locale | liblocale-ruby1.8
 Description: Mauve network alert system -- server
  Mauve is a network alert system for system and network administrators.  You can
  use it to quickly set up ad-hoc monitoring for a variety of services, and to
@@ -25,7 +24,6 @@ Description: Mauve network alert system -- server
 Package: mauvealert-client
 Architecture: all
 Depends: ruby | ruby-interpreter, ruby-protobuf, ${misc:Depends}
-Recommends: liblocale-ruby1.8 | ruby-locale
 Replaces:  mauvealert-common
 Conflicts: mauvealert-common
 Provides: mauvealert-common

--- a/lib/mauve/sender.rb
+++ b/lib/mauve/sender.rb
@@ -1,11 +1,11 @@
 # encoding: UTF-8
 require 'ipaddr'
 require 'socket'
-begin
-  require 'locale'
-rescue LoadError
+#begin
+#  require 'locale'
+#rescue LoadError
   # Do nothing -- these are bonus libraries :)
-end
+#end
 
 require 'mauve/mauve_resolv'
 require 'mauve/mauve_time'

--- a/lib/mauve/sender.rb
+++ b/lib/mauve/sender.rb
@@ -1,11 +1,6 @@
 # encoding: UTF-8
 require 'ipaddr'
 require 'socket'
-#begin
-#  require 'locale'
-#rescue LoadError
-  # Do nothing -- these are bonus libraries :)
-#end
 
 require 'mauve/mauve_resolv'
 require 'mauve/mauve_time'
@@ -151,13 +146,6 @@ module Mauve
       # we have to manually add it here with an explicit `false`.
       # `nil` doesn't work.
       update.replace ||= false
-
-      #
-      # Check the locale charset.  This is to maximise the amout of information
-      # mauve receives, rather than provide proper sanitized data for the server.
-      #
-      from_charset = (Locale.current.charset || Locale.charset) if defined?(Locale)
-      from_charset ||= "UTF-8"
 
       #
       #


### PR DESCRIPTION
Locale is apparently not so useful in modern rubys so I've removed it to get my docker setup working. This doesn't completely remove all reference to the Locale class, just removes the require (since the only reference to Locale checks it exists first)